### PR TITLE
Set default scheme to mailto for open() on iOS

### DIFF
--- a/src/ios/APPEmailComposer.m
+++ b/src/ios/APPEmailComposer.m
@@ -91,6 +91,9 @@
 
     [self.commandDelegate runInBackground:^{
         NSString* scheme = [props objectForKey:@"app"];
+        if (!scheme) {
+            scheme = @"mailto";
+        }
 
         if (![self canUseAppleMail:scheme]) {
             [self openURLFromProperties:props];


### PR DESCRIPTION
If __app__ key is not set on iOS for `open()` the composer will not be opened. 
This change will set the scheme to '__mailto__' if __app__ is not provided.