### PR TITLE
iOS: Fixed crash when no mail clients is configured and changed urlFromProperties

### DIFF
--- a/src/ios/APPEmailComposer.m
+++ b/src/ios/APPEmailComposer.m
@@ -25,6 +25,7 @@
 #ifndef __CORDOVA_4_0_0
     #import <Cordova/NSData+Base64.h>
 #endif
+#import <MessageUI/MFMailComposeViewController.h>
 #import <MobileCoreServices/MobileCoreServices.h>
 
 #include "TargetConditionals.h"
@@ -90,10 +91,10 @@
     _command = command;
 
     [self.commandDelegate runInBackground:^{
-        NSString* scheme = [props objectForKey:@"app"];
-        if (!scheme) {
-            scheme = @"mailto";
+        if (![props objectForKey:@"app"]) {
+            [props setValue:@"mailto" forKey:@"app"];
         }
+        NSString* scheme = [props objectForKey:@"app"];
 
         if (![self canUseAppleMail:scheme]) {
             [self openURLFromProperties:props];
@@ -171,7 +172,7 @@
  */
 - (BOOL) canUseAppleMail:(NSString*) scheme
 {
-    return [scheme hasPrefix:@"mailto"];
+    return [MFMailComposeViewController canSendMail] && [scheme hasPrefix:@"mailto"];
 }
 
 /**

--- a/src/ios/APPEmailComposerImpl.m
+++ b/src/ios/APPEmailComposerImpl.m
@@ -120,6 +120,8 @@
 {
     NSString* mailto     = [props objectForKey:@"app"];
     NSString* query      = @"";
+    
+    BOOL isHTML = [[props objectForKey:@"isHtml"] boolValue];
 
     NSString* subject    = [props objectForKey:@"subject"];
     NSString* body       = [props objectForKey:@"body"];
@@ -137,22 +139,25 @@
               [to componentsJoinedByString:@","]];
 
     if (body.length > 0) {
-        query = [NSString stringWithFormat: @"%@&body=%@",
-                   query, body];
+        if (isHTML) {
+            body = [[NSAttributedString alloc] initWithData:[body dataUsingEncoding:NSUTF8StringEncoding] options:@{NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType, NSCharacterEncodingDocumentAttribute: [NSNumber numberWithInt:NSUTF8StringEncoding]} documentAttributes:nil error:nil].string;
+        }
+        query = [NSString stringWithFormat: @"%@%@body=%@",
+                   query, query.length > 0? @"&":@"", [body stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
     }
     if (subject.length > 0) {
-        query = [NSString stringWithFormat: @"%@&subject=%@",
-                   query, body];
+        query = [NSString stringWithFormat: @"%@%@subject=%@",
+                   query, query.length > 0? @"&":@"", [subject stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
     }
 
     if (cc.count > 0) {
-        query = [NSString stringWithFormat: @"%@&cc=%@",
-                   query, [cc componentsJoinedByString:@","]];
+        query = [NSString stringWithFormat: @"%@%@cc=%@",
+                   query, query.length > 0? @"&":@"", [cc componentsJoinedByString:@","]];
     }
 
     if (bcc.count > 0) {
-        query = [NSString stringWithFormat: @"%@&bcc=%@",
-                   query, [cc componentsJoinedByString:@","]];
+        query = [NSString stringWithFormat: @"%@%@bcc=%@",
+                   query, query.length > 0? @"&":@"", [bcc componentsJoinedByString:@","]];
     }
 
     if (attachments.count > 0) {


### PR DESCRIPTION
Fixed an iOS crash when no mail clients is configured, now we fallback to open url with scheme "mailto" which opens native Mail Client and gives the option to configure a new email, and finally fixed how we build urlFromProperties where it was ignoring isHTML property, escaping possible URL characters, and having invalid subject/bcc query values