### PR TITLE
Remove Android GET_ACCOUNTS permission

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -41,9 +41,6 @@
         <param name="android-package" value="de.martinreinhardt.cordova.plugins.email.EmailComposer"/>
       </feature>
     </config-file>
-    <config-file target="AndroidManifest.xml" parent="/manifest">
-      <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
-    </config-file>
     <source-file src="src/android/EmailComposer.java" target-dir="src/de/martinreinhardt/cordova/plugins/email"/>
     <source-file src="src/android/EmailComposerImpl.java" target-dir="src/de/martinreinhardt/cordova/plugins/email"/>
   </platform>
@@ -52,9 +49,6 @@
       <feature name="EmailComposer">
         <param name="android-package" value="de.martinreinhardt.cordova.plugins.email.EmailComposer"/>
       </feature>
-    </config-file>
-    <config-file target="AndroidManifest.xml" parent="/manifest">
-      <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
     </config-file>
     <source-file src="src/android/EmailComposer.java" target-dir="src/de/martinreinhardt/cordova/plugins/email"/>
     <source-file src="src/android/EmailComposerImpl.java" target-dir="src/de/martinreinhardt/cordova/plugins/email"/>


### PR DESCRIPTION
Requirement for this permission was removed with this change: https://github.com/hypery2k/cordova-email-plugin/commit/f9462c2f66d5db0da73a9c1ffabf342e6c13a6d6#diff-1914e64ebaebcb6f845b7e59c24df370R592
but still specified in AndroidManifest.xml and gets caught by Google Play as a sensitive permission